### PR TITLE
refs #9949: Implemented drush commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
         "drupal/focal_point": "^2.1",
         "drupal/media_responsive_thumbnail": "^2.0",
         "drupal/config_ignore": "^3.3",
-        "drupal/field_group": "^4.0"
+        "drupal/field_group": "^4.0",
+        "drupal/auto_entitylabel": "^3.4"
     },
     "require-dev": {
         "drupal/core-dev": "^11",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11124d2c848406f0f3dfd62327fe7448",
+    "content-hash": "eaf8cd3de1417fdf64cf4daeba0306ea",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1268,6 +1268,87 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/admin_toolbar",
                 "issues": "https://www.drupal.org/project/issues/admin_toolbar"
+            }
+        },
+        {
+            "name": "drupal/auto_entitylabel",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/auto_entitylabel.git",
+                "reference": "8.x-3.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/auto_entitylabel-8.x-3.4.zip",
+                "reference": "8.x-3.4",
+                "shasum": "9b3d7bc8e450ae008b3f48fed0dd9dace03ddbb5"
+            },
+            "require": {
+                "drupal/core": "^10.1 || ^11"
+            },
+            "require-dev": {
+                "drupal/book": "^1.0",
+                "drupal/token": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-3.4",
+                    "datestamp": "1736308389",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bforchhammer",
+                    "homepage": "https://www.drupal.org/user/216396"
+                },
+                {
+                    "name": "colan",
+                    "homepage": "https://www.drupal.org/user/58704"
+                },
+                {
+                    "name": "dqd",
+                    "homepage": "https://www.drupal.org/user/1001934"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "mandclu",
+                    "homepage": "https://www.drupal.org/user/52136"
+                },
+                {
+                    "name": "pravin ajaaz",
+                    "homepage": "https://www.drupal.org/user/2910049"
+                },
+                {
+                    "name": "purushotam.rai",
+                    "homepage": "https://www.drupal.org/user/3193859"
+                },
+                {
+                    "name": "renatog",
+                    "homepage": "https://www.drupal.org/user/3326031"
+                },
+                {
+                    "name": "vladimiraus",
+                    "homepage": "https://www.drupal.org/user/673120"
+                }
+            ],
+            "description": "Allows hiding of entity label fields and automatic label creation.",
+            "homepage": "https://www.drupal.org/project/auto_entitylabel",
+            "support": {
+                "source": "https://git.drupalcode.org/project/auto_entitylabel",
+                "issues": "https://www.drupal.org/project/issues/auto_entitylabel"
             }
         },
         {

--- a/web/modules/custom/drush_news_update_title/drush.services.yml
+++ b/web/modules/custom/drush_news_update_title/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  drush_news_update_title.commands:
+    class: Drupal\drush_news_update_title\Commands\DrushNewsUpdateTitleCommands
+    arguments: ['@entity_type.manager', '@cache.discovery']
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/drush_news_update_title/drush_news_update_title.info.yml
+++ b/web/modules/custom/drush_news_update_title/drush_news_update_title.info.yml
@@ -1,0 +1,5 @@
+name: 'Drush News Update Title'
+type: module
+description: 'Drush command to update all news node titles.'
+core_version_requirement: ^11
+package: Custom

--- a/web/modules/custom/drush_news_update_title/src/Commands/DrushNewsUpdateTitleCommands.php
+++ b/web/modules/custom/drush_news_update_title/src/Commands/DrushNewsUpdateTitleCommands.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\drush_news_update_title\Commands;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Attributes as CLI;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Drush commands for updating news titles.
+ */
+class DrushNewsUpdateTitleCommands extends DrushCommands {
+  use AutowireTrait;
+
+  /**
+   * Constructs a new DrushNewsUpdateTitleCommands object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManagerInterface
+   *   The entity type manager service, used to load and query entities.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cacheDiscovery
+   *   The cache discovery service, used to clear cached field definitions.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManagerInterface,
+    protected CacheBackendInterface $cacheDiscovery,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * Gets the entity type manager service.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   The entity type manager.
+   */
+  public function getEntity(): EntityTypeManagerInterface {
+    return $this->entityTypeManagerInterface;
+  }
+
+  /**
+   * Gets the cache discovery service.
+   *
+   * @return \Drupal\Core\Cache\CacheBackendInterface
+   *   The cache discovery backend service.
+   */
+  public function getCache(): CacheBackendInterface {
+    return $this->cacheDiscovery;
+  }
+
+  /**
+   * Updates news nodes: copies title to field_custom_title.
+   */
+  #[CLI\Command(name: 'drush_news_update_title:update', aliases: ['nut'])]
+  public function updateTitles(): void {
+    $node_storage = $this->getEntity()->getStorage('node');
+    $this->getCache()->deleteAll();
+
+    $nids = $node_storage
+      ->getQuery()
+      ->condition('type', 'news')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    $this->output()->writeln('Found ' . count($nids) . ' news nodes.');
+
+    foreach ($nids as $nid) {
+      $node = $node_storage->load($nid);
+      if (empty($node->field_custom_title->value)) {
+        $node->set('field_custom_title', $node->getTitle());
+        $node_storage->save($node);
+        $this->output()->writeln('Updated node #$nid: ' . $node->getTitle());
+      }
+    }
+
+    $this->logger()->success('All news nodes updated successfully.');
+  }
+
+  /**
+   * Updates news nodes: copies title to field_custom_title using batch.
+   */
+  #[CLI\Command(name: 'drush_news_update_title:batch_update', aliases: ['nutb'])]
+  public function testBatch(): void {
+    $node_storage = $this->getEntity()->getStorage('node');
+    $nids = $node_storage
+      ->getQuery()
+      ->condition('type', 'news')
+      ->accessCheck(FALSE)
+      ->execute();
+
+    $operations = [];
+    foreach ($nids as $nid) {
+      $operations[] = [self::class . '::batchUpdateNode', [$nid]];
+    }
+
+    $batch = [
+      'title' => 'Test Batch',
+      'operations' => $operations,
+      'init_message' => 'Batch starting...',
+      'error_message' => 'An error occurred.',
+    ];
+
+    batch_set($batch);
+    drush_backend_batch_process();
+    $this->output()->writeln('Batch finished.');
+  }
+
+  /**
+   * Batch callback function.
+   */
+  public static function batchUpdateNode($nid, array &$context) {
+    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+
+    $node = $node_storage->load($nid);
+    if (empty($node->get('field_custom_title')->value)) {
+      $node->set('field_custom_title', $node->getTitle());
+      $node_storage->save($node);
+      $context['message'] = "Updated node #$nid";
+    }
+  }
+
+}


### PR DESCRIPTION
Installed the auto_entitylabel module.
Created a custom module.
Created two Drush commands that copy previously created titles to the new field_custom_title(one with batch, another without)